### PR TITLE
Update ListOfListsRoadImpl.java

### DIFF
--- a/TrafficSimulator/src/com/kcl/keepitclean/main/roadnetwork/road/ListOfListsRoadImpl.java
+++ b/TrafficSimulator/src/com/kcl/keepitclean/main/roadnetwork/road/ListOfListsRoadImpl.java
@@ -26,6 +26,9 @@ public class ListOfListsRoadImpl implements Road {
 	private int speedLimit;
 	private Point startCoordinate;
 	private Point endCoordinate;
+	private Junction startJunction= null; //the junction at the start of road
+	private Junction endJunction =null; //the junction at the end of road
+	private boolean hasJunction;
 	
 	private Junction endOfRoad;
         private Orientation orientation;
@@ -140,4 +143,31 @@ public class ListOfListsRoadImpl implements Road {
         public Orientation getOrientation(){
             return this.orientation;
         }
+
+		public Junction getStartJunction() {
+			return startJunction;
+		}
+
+		public void setStartJunction(Junction startJunction) {
+			this.startJunction = startJunction;
+		}
+
+		public Junction getEndJunction() {
+			return endJunction;
+		}
+
+		public void setEndJunction(Junction endJunction) {
+			this.endJunction = endJunction;
+			this.setHasJunction(true);
+			
+		}
+
+		public boolean hasJunction() {
+			if (endJunction== null) return false;
+			else return true;
+		}
+
+		private void setHasJunction(boolean hasJunction) {
+			this.hasJunction = hasJunction;
+		}
 }


### PR DESCRIPTION
roads can now keep track of the junctions they are connected too.


hasJunction() is a bool that returns true if the road is connected to a junction.

setStartJunction and setEnd junction should be called by the map when the junctions are generated.